### PR TITLE
removing Burden from level <100

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -626,6 +626,7 @@ namespace ACE.Server.Managers
                 ("rares_max_seconds_between", new Property<long>(5256000, "for rares_real_time: the maximum number of seconds a player can go before a second chance at a rare is allowed on rare eligible creature kills that did not generate a rare")),
                 ("summoning_killtask_multicredit_cap", new Property<long>(2, "if allow_summoning_killtask_multicredit is enabled, the maximum # of killtask credits a player can receive from 1 kill")),
                 ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects")),
+                ("ignore_burden_below_character_level", new Property<long>(100, "The minimum character level at which burden will start to apply. Retail defaults to 0.")),
                 ("windup_turn_retry_number", new Property<long>(0, "Fixes turning forever during windup. 0 = default / disabled, 1 = retry one time, 2 = retry two times, ...")),
                 ("pvp_damage_cap", new Property<long>(450, "The cap for PvP damage per strike")),
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -68,6 +68,11 @@ namespace ACE.Server.WorldObjects
         public ACE.Entity.Position LastGroundPos;
         public ACE.Entity.Position SnapPos;
 
+        public bool IsBurdenIgnored
+        {
+            get { return this.Level < PropertyManager.GetLong("ignore_burden_below_character_level").Item; }
+        }
+
         public ConfirmationManager ConfirmationManager;
 
         public SquelchManager SquelchManager;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -45,6 +45,8 @@ namespace ACE.Server.WorldObjects
 
         public int GetEncumbranceCapacity()
         {
+            if (this.IsBurdenIgnored)
+                return 10000000;
             var strength = Attributes[PropertyAttribute.Strength].Current;
 
             return (int)((150 * strength) + (AugmentationIncreasedCarryingCapacity * 30 * strength));

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -334,6 +334,10 @@ namespace ACE.Server.WorldObjects
 
                 Session.Network.EnqueueSend(levelUp);
 
+                var ignore_burden_below_character_level = PropertyManager.GetLong("ignore_burden_below_character_level").Item;
+                if (startingLevel < ignore_burden_below_character_level && Level >= ignore_burden_below_character_level)
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"WARNING: Your level has reached {Level.Value} you now suffer from the effects of burden! (This effect may not be applied until the next time you log in.)", ChatMessageType.Broadcast));
+
                 SetMaxVitals();
 
                 // play level up effect

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1874,7 +1874,18 @@ namespace ACE.Server.WorldObjects
         public int? EncumbranceVal
         {
             get => GetProperty(PropertyInt.EncumbranceVal);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.EncumbranceVal); else SetProperty(PropertyInt.EncumbranceVal, value.Value); }
+            set { 
+                if (!value.HasValue)
+                    RemoveProperty(PropertyInt.EncumbranceVal);
+                else
+                {
+                    //Player will need to relog once they are past the level limit for burden.
+                    //Couldn't find any way around this as the packet for EncumbranceCapacity seems to be ignored by the client. 
+                    if (this is Player && this.Level < PropertyManager.GetLong("ignore_burden_below_character_level").Item)
+                        value = 0;
+                    SetProperty(PropertyInt.EncumbranceVal, value.Value);
+                }
+            }
         }
 
         public double? BulkMod


### PR DESCRIPTION
if your character is under level 100 you will not carry the effects of burden. if the player levels to 100+ they will get the effects after a relog.