### PR TITLE
Hotspot initial commit

### DIFF
--- a/Source/ACE.Server/Entity/Hotspots/HotspotLandblocks.cs
+++ b/Source/ACE.Server/Entity/Hotspots/HotspotLandblocks.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Server.Entity
+{
+    public static class HotspotLandblocks
+    {
+
+        private static Dictionary<uint, HotspotArea> _hotspotLandblocksMap;
+
+        public static Dictionary<uint, HotspotArea> HotspotLandblocksMap
+        {
+            get
+            {
+                if (_hotspotLandblocksMap == null)
+                {
+                    _hotspotLandblocksMap = new Dictionary<uint, HotspotArea>();
+
+                    //Irwin's Demise
+                    var irwins = new HotspotArea();
+                    irwins.MaxPlayersPerAllegiance = 2;
+                    irwins.AreaLandblockIds = new uint[] { 0xF2EA };
+                    _hotspotLandblocksMap.Add(0xF2EA, irwins);
+                }
+
+                return _hotspotLandblocksMap;
+            }
+        }
+
+        public static bool IsHotspotLandblock(uint landblockId)
+        {
+            return HotspotLandblocksMap.ContainsKey(landblockId);
+        }
+
+        public static HotspotArea GetLandblockHotspotArea(uint landblockId)
+        {
+            if (IsHotspotLandblock(landblockId))
+            {
+                return HotspotLandblocksMap[landblockId];
+            }
+
+            return null;
+        }
+    }
+
+    public class HotspotArea
+    {
+        public uint[] AreaLandblockIds;
+        public uint MaxPlayersPerAllegiance;
+    }
+}


### PR DESCRIPTION
Creates the framework for having "hotspots" - areas that are restricted to only a certain number of players per allegiance.

This currently handles checking number of players in same allegiance in the hotspot area at the time of teleporting in (this is assuming its an enclosed area that can't be accessed by just walking in and doesn't allow relogging.

Future commit will add logic to kick allegiance members if entering a landblock without exiting a portal